### PR TITLE
Fix undefined symbols in newer distros.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/KiCad/
+/build/

--- a/recipes/KiCad.yml
+++ b/recipes/KiCad.yml
@@ -23,8 +23,7 @@ script:
   # Remove any previous build
   - rm -rf KiCad
   - cp /lib/x86_64-linux-gnu/libpango-1.0.so.0 ./lib/x86_64-linux-gnu/libpango-1.0.so.0
-  - cp /usr/lib/x86_64-linux-gnu/libpangoft2-1.0.so.0 ./usr/lib/x86_64-linux-gnu/libpangoft2-1.0.so.0
-  - cp /usr/lib/x86_64-linux-gnu/libgtk-3.so.0 ./usr/lib/x86_64-linux-gnu/libgtk-3.so.0
+  - cp /usr/lib/x86_64-linux-gnu/lib*.so.* ./usr/lib/x86_64-linux-gnu/
   - cp -r /usr/lib/python3/ ./usr/lib
   - # Workaround until
   - # AppRun.c exports rather than just sets environment variables


### PR DESCRIPTION
Fixes #1.

I ran into #1 and when looking into it, I found a huge and growing dependency tree. This change just copies over all the shared libraries into the image. Given the size of kicad, I don't think this additional bloat is too bad.

there's at least some precedence with this for other big applications that require a large amount of dependencies
https://github.com/AppImageCommunity/pkg2appimage/blob/199fc9f768b35ad6166109299e5cf3832adeb5d5/legacy/freecad/Recipe#L61