### PR TITLE
Fix to compile AppImage on Ubuntu 24.04 and pull correct pkg2appimage (x86)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -10,8 +10,8 @@ RUN apt update \
     libfuse2 \
     file \
     binutils \
-    python3.8 \
-    libpython3.8 \
+    python3.10 \
+    libpython3.10 \
     libjpeg-turbo8 \
     libtiff5 \
     libwebp-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,11 @@ RUN apt update \
     libglu1-mesa \
     libsm6 \
     libopengl0 \
+    imagemagick \
     gir1.2-xapp-1.0 libxapp1 xapps-common python3-xapp
 
 RUN curl -s https://api.github.com/repos/AppImageCommunity/pkg2appimage/releases \
-  | grep "browser_download_url.*AppImage" \
+  | grep "browser_download_url.*-x86_64\.AppImage" \
   | cut -d : -f 2,3 \
   | tr -d \" \
   | head -n 1 \

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 base: build
 	@rm -rf ./KiCad/KiCad.AppDir ./KiCad/kicad-packages3d*.deb
 	@sed -i '/kicad-packages3d/c\#    - kicad-packages3d' recipes/KiCad.yml
-	@../pkg2appimage--x86_64.AppImage recipes/KiCad.yml
+	@../pkg2appimage-*-x86_64.AppImage recipes/KiCad.yml
 	@mv ./out ./build/$@
 
 3d: build
 	@sed -i '/kicad-packages3d/c\    - kicad-packages3d' recipes/KiCad.yml
-	@../pkg2appimage--x86_64.AppImage recipes/KiCad.yml
+	@../pkg2appimage-*-x86_64.AppImage recipes/KiCad.yml
 	@mv ./out ./build/$@
 	@sed -i '/kicad-packages3d/c\#    - kicad-packages3d' recipes/KiCad.yml
 

--- a/recipes/KiCad.yml
+++ b/recipes/KiCad.yml
@@ -12,12 +12,12 @@ ingredients:
     - libcurl4
     - libpython3.8
 
-# Mimimum supported version is Ubuntu 20.04
-  dist: focal
+# Mimimum supported version is Ubuntu 22.04
+  dist: jammy
   sources:
-    - deb http://us.archive.ubuntu.com/ubuntu/ focal main universe
+    - deb http://us.archive.ubuntu.com/ubuntu/ jammy main universe
   ppas:
-    - kicad/kicad-8.0-releases
+    - kicad/kicad-9.0-releases
 
 script:
   # Remove any previous build
@@ -44,10 +44,11 @@ script:
   - export LD_LIBRARY_PATH="${HERE}"/usr/lib/x86_64-linux-gnu/:"${HERE}"/lib/x86_64-linux-gnu/:"${HERE}"/usr/lib/:"${HERE}"/lib/:$LD_LIBRARY_PATH
   - cd "${HERE}/usr"
   - unset GTK3_MODULES
-  - export KICAD8_3DMODEL_DIR="${HERE}/usr/share/kicad/3dmodels"
-  - export KICAD8_FOOTPRINT_DIR="${HERE}/usr/share/kicad/footprints"
-  - export KICAD8_SYMBOL_DIR="${HERE}/usr/share/kicad/symbols"
-  - export KICAD8_TEMPLATE_DIR="${HERE}/usr/share/kicad/template"
+  - export KICAD9_3DMODEL_DIR="${HERE}/usr/share/kicad/3dmodels"
+  - export KICAD9_FOOTPRINT_DIR="${HERE}/usr/share/kicad/footprints"
+  - export KICAD9_SYMBOL_DIR="${HERE}/usr/share/kicad/symbols"
+  - export KICAD9_TEMPLATE_DIR="${HERE}/usr/share/kicad/template"
+  - export KICAD9_DESIGN_BLOCK_DIR="${HERE}/usr/share/kicad/blocks"
   - if [ ! -z "$1" ] && [ -e "${HERE}/usr/bin/$1" ]; then
   -   EXEC="${HERE}/usr/bin/$1"; shift
   - else


### PR DESCRIPTION
- changes to compile and build under ubuntu 24.04
- fix to download correct architecture of pkg2appimage and use it in build process